### PR TITLE
Change provider injection for minification parity

### DIFF
--- a/statehelper.js
+++ b/statehelper.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 angular.module('ui.router.stateHelper', ['ui.router'])
-    .provider('stateHelper', function($stateProvider){
+    .provider('stateHelper', ["$stateProvider", function($stateProvider){
         var self = this;
 
         /**
@@ -41,5 +41,5 @@ angular.module('ui.router.stateHelper', ['ui.router'])
                 state.name = state.parent.name + '.' + state.name;
             }
         }
-    })
+    }])
 ;


### PR DESCRIPTION
If the js is minified by another system, the parameter specifying `$stateprovider` would be converted to single character, thus breaking the injector.
