### PR TITLE
Use inline array dependency annotation

### DIFF
--- a/statehelper.js
+++ b/statehelper.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 angular.module('ui.router.stateHelper', ['ui.router'])
-    .provider('stateHelper', function($stateProvider){
+    .provider('stateHelper', ['$stateProvider', function($stateProvider){
         var self = this;
 
         /**
@@ -44,5 +44,5 @@ angular.module('ui.router.stateHelper', ['ui.router'])
                 state.name = state.parent.name + '.' + state.name;
             }
         }
-    })
+    }])
 ;


### PR DESCRIPTION
It would be nice to have inline array dependency annotation to prevent minification issue and also keep sync with "statehelper.min.js" (because it uses that approach).
